### PR TITLE
parsing vanitybytes as hexstring

### DIFF
--- a/vanity.c
+++ b/vanity.c
@@ -121,6 +121,15 @@ int main(int argc, char** argv) {
 
     uint8_t* vanity = (uint8_t*) argv[4];
     int vlen = strlen(argv[4]);
+
+    if(vlen>3 && vlen%2==0 && vanity[0]=='0' && vanity[1]=='x') {
+        printf("[*] parsing vanitybytes as hexstring\n");
+        for(int i = 2; i<vlen; i+=2) {
+            vanity[i/2-1]=char2int(vanity[i])*16+char2int(vanity[i+1]);
+        }
+        vlen=vlen/2-1;
+    }
+    
     printf("[*] Searching for: 0x...");
     int i;
     for(i = 0; i < vlen; i++)


### PR DESCRIPTION
By parsing value from command line I didn't know how to input values greater than 127
So I added a way to parse hex strings to use like this:
`./vanity ../.gnupg/pubring.gpg ../.gnupg/secring.gpg 100 0xbeef`